### PR TITLE
[Fix] Bug with updating quest credits

### DIFF
--- a/src/resolvers/quests.ts
+++ b/src/resolvers/quests.ts
@@ -141,7 +141,7 @@ const QuestMutations = {
         $set: {
           ...mergeWithCustomizer(originalQuest, newInput),
           ...(newInput.data ? { data: newInput.data } : {}),
-          ...(newInput.credits ? { data: newInput.credits } : {}),
+          ...(newInput.credits ? { credits: newInput.credits } : {}),
         },
       },
       { returnOriginal: false });


### PR DESCRIPTION
When I edited credits, data saved to `data` field.